### PR TITLE
Add auto load new input system on editor versions >= 2019.4+

### DIFF
--- a/RMC Mini MVCS/Editor.meta
+++ b/RMC Mini MVCS/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a423b33d324c714aaf214f53b822757
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RMC Mini MVCS/Editor/RMC.Core.Mini.Editor.asmdef
+++ b/RMC Mini MVCS/Editor/RMC.Core.Mini.Editor.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "RMC.Core.Mini.Editor",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2019.4.0",
+            "define": "EDITOR_VERSION_CHECK"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/RMC Mini MVCS/Editor/RMC.Core.Mini.Editor.asmdef.meta
+++ b/RMC Mini MVCS/Editor/RMC.Core.Mini.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e603e68a63b187149836a8fa8c10a2d5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RMC Mini MVCS/Editor/RMC.meta
+++ b/RMC Mini MVCS/Editor/RMC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88ae2c07d318b084aa5857be0c39792a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RMC Mini MVCS/Editor/RMC/Core.meta
+++ b/RMC Mini MVCS/Editor/RMC/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1f69bd3f4541c54db47d9f32d951956
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RMC Mini MVCS/Editor/RMC/Core/Helper.meta
+++ b/RMC Mini MVCS/Editor/RMC/Core/Helper.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfe961c0122be1742a3ab4a391bec867
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RMC Mini MVCS/Editor/RMC/Core/Helper/EditorVersionCheck.cs
+++ b/RMC Mini MVCS/Editor/RMC/Core/Helper/EditorVersionCheck.cs
@@ -1,0 +1,110 @@
+#if EDITOR_VERSION_CHECK
+
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
+using UnityEngine;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+
+namespace RMC_Mini_MVCS.Editor.RMC.Core.Helper
+{
+    public static class EditorVersionCheck
+    {
+        private const string Menu = "Tutorials";
+        private const string MenuPath = Menu + "/";
+        private const string ShowTutorials = "Reset PackageInstalled Switch";
+        
+        private const string Packagename = "com.unity.inputsystem";
+        private static PackageInfo packageInfo;
+        private static bool _packagePresent = false;
+        private static bool _packageInstalled = false;
+        private static AddRequest AddRequest;
+        private static ListRequest ListRequest;
+
+
+        [MenuItem(MenuPath + ShowTutorials, priority = -99)]
+        private static void ResetPackageInstalledSwitch()
+        {
+            EditorPrefs.SetBool("PackageInstalled", false);
+            EditorUtility.RequestScriptReload();
+            EditorApplication.Step();
+        }
+        
+        [InitializeOnLoadMethod]
+        private static void CheckVersionDependency()
+        {
+            _packageInstalled = EditorPrefs.GetBool("PackageInstalled");
+            if (!_packageInstalled)
+            {
+                Debug.Log($"It seems like the package: '{Packagename}' is not installed." 
+                          + $"\nBut it is needed on Unity Editor versions higher then: 2019.4.+");
+                ListRequest = Client.List();
+                EditorApplication.update += ListProgress;
+                Debug.Log($"Searching for Package: '{Packagename}'...");
+            }
+        }
+        
+        private static void ListProgress()
+        {
+            if (!ListRequest.IsCompleted) return;
+            
+            switch (ListRequest.Status)
+            {
+                case StatusCode.Success:
+                {
+                    foreach (var result in ListRequest.Result)
+                    {
+                        _packagePresent = result.packageId.Contains(Packagename);
+                        if (_packagePresent)
+                            break;
+                    }
+
+                    Debug.Log(_packagePresent
+                        ? $"Package: '{Packagename}' is already installed. No need to import it."
+                        : $"Package: '{Packagename}' not installed. Importing it...");
+                    break;
+                }
+                case >= StatusCode.Failure:
+                    Debug.Log(ListRequest.Error.message);
+                    _packagePresent = false;
+                    break;
+            }
+
+            EditorApplication.update -= ListProgress;
+            if (ListRequest.IsCompleted && !_packagePresent)
+            {
+                AddRequest = Client.Add(Packagename);
+                EditorApplication.update += AddProgress;
+            }
+            else
+            {
+                EditorPrefs.SetBool("PackageInstalled", true);
+            }
+        }
+        
+        private static void AddProgress()
+        {
+            if (!AddRequest.IsCompleted) return;
+            
+            switch (AddRequest.Status)
+            {
+                case StatusCode.Success:
+                    Debug.Log($"Successfully installed: '{AddRequest.Result.packageId}'.");
+                    break;
+                case >= StatusCode.Failure:
+                    Debug.LogError(AddRequest.Error.message);
+                    Debug.LogError(
+                        $"Could not install package: '{AddRequest.Result.packageId}'. Try manually in the 'Package Manager.");
+                    break;
+            }
+
+            EditorApplication.update -= AddProgress;
+            EditorUtility.RequestScriptReload();
+            EditorApplication.Step();
+            EditorPrefs.SetBool("PackageInstalled", true);
+        }
+    }
+}
+
+#endif

--- a/RMC Mini MVCS/Editor/RMC/Core/Helper/EditorVersionCheck.cs.meta
+++ b/RMC Mini MVCS/Editor/RMC/Core/Helper/EditorVersionCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e47b440d7feba68428d9507c23b84397
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR tries to tackle  an issue described in issue #4 
Where loading the samples caused compilation erros if the new input system package was missing.

Reproduction steps:

1. Add the 'RMC Mini MVCS' package to a empty Unity (in my case 2022.3.16f1) project.
2. Go to _Window_ > _Package Manager_ > _RMC Mini MVCS_ > _Samples_ > _Import_
3. The editor compiles and shows the following errors.

![image](https://github.com/SamuelAsherRivello/rmc-mini-mvcs/assets/6112303/df47bb73-3c28-467e-b986-a74d44157f0e)


The problem is, your AWESOME (really man, I learned soo much reading your code) package validator script does not kick in because of the compile errors, and the button under _Tutorials_ does not show up. I found it later after digging in and fixing it by myself. That's what inspired me to create the step before.

Cheers
    Khaled
    
P.S: Obvisouly open for any discussion/suggestion/learning. 😊