### PR TITLE
PR- Fix __rigidbody.linearVelocity Roll a Ball With Mini Example Advanced

### DIFF
--- a/RMC Mini MVCS/Samples~/RMC Mini MVCS - 1. Beginner Examples/Examples/Example03_RollABallMini/Advanced/WithMini/Scripts/Runtime/Mini/View/PlayerView.cs
+++ b/RMC Mini MVCS/Samples~/RMC Mini MVCS - 1. Beginner Examples/Examples/Example03_RollABallMini/Advanced/WithMini/Scripts/Runtime/Mini/View/PlayerView.cs
@@ -39,14 +39,14 @@ namespace RMC.Mini.Samples.RollABall.WithMini.Mini.View
                     _canMove = value;
                     if (!_canMove)
                     {
-                        _lastVelocityBeforePause = _rigidBody.linearVelocity;
+                        _lastVelocityBeforePause = _rigidBody.velocity;
                         _lastAngularVelocityBeforePause = _rigidBody.angularVelocity;
-                        _rigidBody.linearVelocity = Vector3.zero;
+                        _rigidBody.velocity = Vector3.zero;
                         _rigidBody.angularVelocity = Vector3.zero;
                     }
                     else
                     {
-                        _rigidBody.linearVelocity = _lastVelocityBeforePause;
+                        _rigidBody.velocity = _lastVelocityBeforePause;
                         _rigidBody.angularVelocity = _lastAngularVelocityBeforePause;
                   
                     }


### PR DESCRIPTION
Tested on RollABallWithMiniExampleAdvanced

This pull request includes an update to the PlayerView class in the Example03_RollABallMini project. The changes involve modifying the properties used for handling the player's movement.

Changes to PlayerView class:

[RMC Mini MVCS/Samples~/RMC Mini MVCS - 1. Beginner Examples/Examples/Example03_RollABallMini/Advanced/WithMini/Scripts/Runtime/Mini/View/PlayerView.cs](https://github.com/DakkuaDev/rmc-mini-mvcs/pull/1/files#diff-b5c2b83267ca2913905cd94663937ed1f3bdc2fd7cd19355d3372f8885434397L42-R49): Updated the CanMove property to use _rigidBody.velocity instead of _rigidBody.linearVelocity for handling the player's movement and pausing behavior.